### PR TITLE
fix: fastapi.logger causes 500 on all HTTP exceptions

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, Request, logger
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse

--- a/backend/src/shared/exceptions.py
+++ b/backend/src/shared/exceptions.py
@@ -1,7 +1,11 @@
-from fastapi import HTTPException, Request, logger
+import logging
+
+from fastapi import HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
+
+logger = logging.getLogger(__name__)
 
 
 async def http_exception_handler(request: Request, exc: StarletteHTTPException):


### PR DESCRIPTION
## Problem\n\n`fastapi.logger` is not a real Python logger — it has no `.warning()` or `.exception()` methods. Every time an HTTPException was raised (401, 403, 404, 409...), the exception handler would crash trying to call `logger.warning()`, returning a 500 instead of the correct status code.\n\n## Fix\n\nReplaced `from fastapi import ..., logger` with stdlib `import logging; logger = logging.getLogger(__name__)` in `shared/exceptions.py` and removed the unused `logger` import from `main.py`.\n\n## Impact\n\nWithout this fix, **all protected endpoints return 500 instead of 401/403/404/409**. This is a frontend blocker.