### PR TITLE
fix auth redirects

### DIFF
--- a/frontend/src/components/auth/ProtectedRoute.jsx
+++ b/frontend/src/components/auth/ProtectedRoute.jsx
@@ -2,8 +2,12 @@ import { useAuthContext } from '../../context/AuthContext';
 import { Navigate, useLocation } from 'react-router';
 
 export default function ProtectedRoute({ children }) {
-  const { isAuthenticated } = useAuthContext();
+  const {isAuthenticated, isAuthReady} = useAuthContext();
   const location = useLocation();
+
+  if (!isAuthReady) {
+    return <div>Loading...</div>
+  }
 
   if (!isAuthenticated) {
     return <Navigate to="/login" state={{ from: location }} replace />;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -13,12 +13,14 @@ export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [accessToken, setAccessToken] = useState(null);
+  const [isAuthReady, setIsAuthReady] = useState(false)
 
   const loginSuccess = (payload) => {
     setIsAuthenticated(true);
     setAccessToken(payload.user_info.access_token);
     setAxiosAccessToken(payload.user_info.access_token);
     setUser(payload.user_info);
+    setIsAuthReady(true)
   };
 
   const logout = () => {
@@ -27,6 +29,7 @@ export function AuthProvider({ children }) {
     setAccessToken(null);
     setAxiosAccessToken(null);
     setUser(null);
+    setIsAuthReady(true)
   };
 
   const refreshToken = async () => {
@@ -39,6 +42,8 @@ export function AuthProvider({ children }) {
       setAccessToken(null);
       setUser(null);
       setIsAuthenticated(false);
+    } finally {
+      setIsAuthReady(true)
     }
   };
 
@@ -48,6 +53,7 @@ export function AuthProvider({ children }) {
     user,
     isAuthenticated,
     accessToken,
+    isAuthReady
   };
 
   return (


### PR DESCRIPTION
problem
```
if you login and then go to pages like /settings
it will redirect to the /login page (thinking you're not logged in) then say you're already logged in
it should stay in the /settings page
```

this PR fixes that, didn't remember that problem last time maybe something was restructured, but this is more robust anyway